### PR TITLE
Adding explicit target deps to BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -17,7 +17,10 @@ sdk_output_dir = "${root_out_dir}/sdk"
 group("sdk") {
   deps = [
     ":generate_dart_packages",
+    ":make_vars",
+    ":sdk_includes",
     ":sdk_library",
+    ":shell_vars"
   ]
 }
 


### PR DESCRIPTION
Previously, gn would implicitly execute all targets in a build file. This has
since changed.

Change-Id: I8096ff208dcd4414d50d76e7485cdf401736ccf2