### PR TITLE
Make scripts aware of GN's configuration dir.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -60,6 +60,7 @@ action("sdk_includes") {
   output = "${sdk_output_dir}/include"
   script = "scripts/copy-includes.py"
   args = [
+           root_out_dir,
            rebase_path("//"),
            rebase_path(output),
            "!//third_party/",
@@ -77,6 +78,7 @@ action("make_vars") {
   script = "scripts/generate-vars.py"
   output = "${sdk_output_dir}/fuchsia.makevars"
   args = [
+    root_out_dir,
     rebase_path("//"),
     "//sdk:sdk_library",
     rebase_path(output),
@@ -91,6 +93,7 @@ action("shell_vars") {
   output = "${sdk_output_dir}/fuchsia.env"
   args = [
     "--format=sh",
+    root_out_dir,
     rebase_path("//"),
     "//sdk:sdk_library",
     rebase_path(output),

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -8,12 +8,12 @@ def normalize_target(target):
     if ':' in target: return target
     return target + ':' + os.path.basename(target)
 
-def gn_desc(target, *what_to_show):
+def gn_desc(root_out_dir, target, *what_to_show):
     # gn desc may fail transiently for an unknown reason; retry loop
     for i in xrange(2):
         desc = subprocess.check_output([
             os.path.join(os.environ['FUCHSIA_DIR'], 'packages', 'gn',
-                         'desc.py'), '--format=json', target
+                         'gn.py'), 'desc', root_out_dir, '--format=json', target
         ] + list(what_to_show))
         try:
             output = json.loads(desc)

--- a/scripts/generate-vars.py
+++ b/scripts/generate-vars.py
@@ -23,8 +23,9 @@ import sys
 from common import *
 
 class Generator(object):
-  def __init__(self, fuchsia_root):
-    self._root = fuchsia_root
+  def __init__(self, root_out_dir, src_root):
+    self._root_out_dir = root_out_dir
+    self._src_root = src_root
 
   def _tweak_flags(self, flags):
     """Adjust CC/CXX/LD flags for out-of-tree use"""
@@ -32,20 +33,20 @@ class Generator(object):
     for flag in flags:
       if '=../' in flag:
         # an out-dir relative path
-        flag = flag.replace('=../', '=' + self._root + '/out/')
+        flag = flag.replace('=../', '=' + self._src_root + '/out/')
       tweaked.append(flag)
     return tweaked
 
   def _path(self, gn_path):
     """Turn a gn path into a real path"""
-    return os.path.normpath(self._root + gn_path)
+    return os.path.normpath(self._src_root + gn_path)
 
   def _join(self, args):
     """Join a list of arguments to be passed to a shell"""
     return ' '.join(args)
 
   def generate(self, target):
-    library_desc = gn_desc(target)
+    library_desc = gn_desc(self._root_out_dir, target)
 
     # Start with the common cflags
     base_cflags = self._tweak_flags(library_desc['cflags'])
@@ -68,7 +69,7 @@ class Generator(object):
     libs = [self._path(l) for l in library_desc['outputs']]
 
     # TODO: work out how to extract CC, CXX, LD from gn or ninja.
-    toolchain_dir = glob.glob(self._root +
+    toolchain_dir = glob.glob(self._src_root +
                               '/buildtools/toolchain/clang+llvm-*/bin/')
     assert (len(toolchain_dir) == 1)
     toolchain_dir = os.path.normpath(toolchain_dir[0])
@@ -87,12 +88,13 @@ class Generator(object):
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()
   parser.add_argument('--format', choices=('make', 'sh'), default='make')
-  parser.add_argument('root')
+  parser.add_argument('root_out_dir')
+  parser.add_argument('src_root')
   parser.add_argument('target')
   parser.add_argument('output')
   args = parser.parse_args()
 
-  generator = Generator(args.root)
+  generator = Generator(args.root_out_dir, args.src_root)
 
   with open(args.output, 'w') as f:
     for k, v in generator.generate(args.target).items():


### PR DESCRIPTION
This has to do with how gn desc is invoked. It now uses a method that is
aware of your out/debug-* or out/release-* dir, and doesn't just assume
a configuration that is maybe not correct.

Change-Id: I8e846eae72e7aa259b002638379e16ccce50403b